### PR TITLE
Set client_max_body_size to 100M so that it can import the largest STIGS without further changes.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,6 +7,8 @@ http {
         listen                      443 ssl;
         server_name                 localhost;
         root                        /usr/share/nginx/html;
+        client_max_body_size        100M;
+
         
         ssl_certificate             /etc/nginx/cert.pem;
         ssl_certificate_key         /etc/nginx/privkey.pem;


### PR DESCRIPTION
Set client_max_body_size to 100M in nginx.conf so that it can import the largest STIGS without further changes.