### PR TITLE
Added the suggested DB config options to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     image: mysql:8.0.21
     # alternative image from Ironbank
     # image: registry1.dso.mil/ironbank/opensource/mysql/mysql8:8.0.21
+    command: --innodb-buffer-pool-size=512M --sort_buffer_size=64M 
     environment:
       - MYSQL_ROOT_PASSWORD=rootpw
       - MYSQL_USER=stigman


### PR DESCRIPTION
Added the MySQL config options that are suggested in the [STIGMan documentation](https://stig-manager.readthedocs.io/en/latest/installation-and-setup/db.html#configure-mysql) to the sample docker-compose file. 