### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,26 +23,22 @@ services:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=Pa55w0rd
       - KC_PROXY=edge
-      - KC_HOSTNAME_URL=https://localhost/kc/
+      - KC_HOSTNAME=Your_DNS_Hostnamne
       - KC_HOSTNAME_ADMIN_URL=https://localhost/kc/
-      - KC_SPI_X509CERT_LOOKUP_PROVIDER=nginx
-      - KC_SPI_X509CERT_LOOKUP_NGINX_SSL_CLIENT_CERT=SSL-CLIENT-CERT
       - KC_SPI_TRUSTSTORE_FILE_FILE=/tmp/truststore.p12
       - KC_SPI_TRUSTSTORE_FILE_PASSWORD=password
     command: start --import-realm
     volumes:
       - ./certs/dod/Certificates_PKCS7_v5.9_DoD.pem.p12:/tmp/truststore.p12
       - ./kc/stigman_realm.json:/opt/keycloak/data/import/stigman_realm.json
-      - ./kc/create-x509-user.jar:/opt/keycloak/providers/create-x509-user.jar
-      # uncomment below to persist Keycloak data
-      # - ./kc/h2:/opt/keycloak/data/h2
+     - ./kc/h2:/opt/keycloak/data/h2
   stigman:
     image: nuwcdivnpt/stig-manager:latest
     # alternative image based on Ironbank Node.js
     # image: nuwcdivnpt/stig-manager:latest-ironbank
     environment:
       - STIGMAN_OIDC_PROVIDER=http://keycloak:8080/realms/stigman
-      - STIGMAN_CLIENT_OIDC_PROVIDER=https://localhost/kc/realms/stigman
+      - STIGMAN_CLIENT_OIDC_PROVIDER=https://Your_DNS_Hostnamne/realms/stigman
       - STIGMAN_CLASSIFICATION=U
       - STIGMAN_DB_HOST=mysql
       - STIGMAN_DB_USER=stigman
@@ -62,6 +58,6 @@ services:
       - MYSQL_PASSWORD=stigmanpw
     # uncomment below to persist MySQL data
     # volumes:
-    #   - ./mysql-data:/var/lib/mysql
+      - ./mysql-data:/var/lib/mysql
 
     


### PR DESCRIPTION
This version will allow Application to be shared among multiple users by using a DNS hostname instead of localhost only.  Users can sign into keycloak and create local accounts instead of needing certificate based authentication.